### PR TITLE
When adding a user to org, make sure it's admin

### DIFF
--- a/recipes/chef-server.rb
+++ b/recipes/chef-server.rb
@@ -95,7 +95,7 @@ node['chef-server']['admins'].each { |admin|
 
 node['chef-server']['admins'].each { |admin|
   execute "org_user_add_#{admin}" do
-    command "chef-server-ctl org-user-add \"#{node['chef-server']['org_short_name']}\" #{admin}"
+    command "chef-server-ctl org-user-add \"#{node['chef-server']['org_short_name']}\" #{admin} --admin"
     action :run
   end
 }


### PR DESCRIPTION
Following investigation of error
```
You authenticated successfully to https://chef-server.revenants.net/organizations/revenants/ as deployer but you are not authorized for this action.
```
I found this answer

https://stackoverflow.com/questions/40621275/knife-bootstrap-error-successful-authentication-but-not-authorized-for-this-ac

I don't use that flag. However I admit, it's confusing, it calls `chef-server-ctl grant-server-admin-permissions`. Doesn't it have effect?
deployer is listed as admin...

```
pivotal
tamas
istvan
peter
aleks
arubin
deployer
```