### PR TITLE
Ensure delivery chef-solo output

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,6 +11,7 @@ default['chef-server']['aws_secret_access_key'] = nil
 default['chef-server']['aws_region'] = 'us-east-1'
 default['chef-server']['backups_bucket'] = nil
 default['chef-server']['cron_mailto'] = 'root'
+default['chef-server']['cron_mailfrom'] = 'root'
 
 default['postfix']['relayhost'] = '[email-smtp.us-east-1.amazonaws.com]:587'
 default['postfix']['smtp_username'] = nil

--- a/files/chef-solo.py
+++ b/files/chef-solo.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+import socket
+from subprocess import Popen
+
+import sys
+
+CHEF_SOLO_LOG_FILE = "/var/log/chef-solo.log"
+
+
+def main():
+    with open(CHEF_SOLO_LOG_FILE, "a") as fp:
+        proc = Popen(
+            ["chef-solo", "-j", "/etc/chef/node.json", "-c", "/etc/chef/solo.rb"],
+            stdout=fp,
+            stderr=fp,
+        )
+        proc.communicate()
+        if proc.returncode:
+            print(
+                "chef-solo exited with non-zero. Check %s on %s."
+                % (CHEF_SOLO_LOG_FILE, socket.gethostname())
+            )
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/recipes/chef-solo.rb
+++ b/recipes/chef-solo.rb
@@ -39,10 +39,23 @@ execute 'pull_cookbook_dependencies' do
     cwd "#{cookbooks_dir}/chef-server"
 end
 
+chef_solo_wrapper_path = '/usr/local/bin/chef-solo.py'
+cookbook_file chef_solo_wrapper_path do
+    source 'chef-solo.py'
+    mode '0755'
+    owner 'root'
+    group 'root'
+end
+
 cron 'chef-solo' do
     minute '*/30'
-    command 'OUTPUT=$(chef-solo -j /etc/chef/node.json -c /etc/chef/solo.rb 2>&1 | tee -a /var/log/chef-solo.log) || echo "$OUTPUT"'
+    command chef_solo_wrapper_path
     mailto node['chef-server']['cron_mailto']
+    environment(
+        {
+            :MAILFROM => node['chef-server']['cron_mailfrom']
+        }
+    )
 end
 
 logrotate_app 'chef-solo' do


### PR DESCRIPTION
* To make cron file nicer wrap chef-solo in a python script
* Define MAILFROM to override default root@. Amazon SES doesn't like unverified emails. Our account is in a sandbox and so be it that way.