### PR TITLE
Try to download key until its size > 0

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -35,8 +35,8 @@ suites:
             accept_license: true
             aws_access_key_id: <%= ENV['CERTBOT_AWS_ACCESS_KEY_ID'] %>
             aws_secret_access_key: <%= ENV['CERTBOT_AWS_SECRET_ACCESS_KEY'] %>
-            zones: ['foo.com', 'bar.com']
-            ssl_admin_email: 'admin@foo.bar'
+            zones: ['revdb.dev', ]
+            ssl_admin_email: 'admin@revdb.dev'
             dry_run: true
         artifactory:
             username: <%= ENV['ARTIFACTORY_USERNAME'] %>

--- a/recipes/certbot.rb
+++ b/recipes/certbot.rb
@@ -38,7 +38,7 @@ execute_environment = {
     :PATH => "/opt/certbot-wrapper/bin"
 }
 execute 'obtain_certificates' do
-  command "certbot-wrapper #{dry_run_arg} certonly #{zone_arg} --email #{node['certbot']['ssl_admin_email']}"
+  command "certbot-wrapper #{dry_run_arg} --sleep-delay 0 certonly #{zone_arg} --email #{node['certbot']['ssl_admin_email']}"
   environment execute_environment
   creates '/etc/letsencrypt/live/README'
   action :run

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -29,8 +29,8 @@ node['chef-server']['admins'].each { |usr|
       command "aws secretsmanager get-secret-value "\
         "--region #{node['chef-server']['aws_region']} "\
         "--secret-id /chef-server/users/#{usr}/key "\
-        "| jq -r .SecretString > /home/#{usr}/.chef/#{usr}.pem"
-      creates "/home/#{usr}/.chef/#{usr}.pem"
+        "| jq -r .SecretString > /home/#{usr}/.chef/#{usr}.pem 2> /home/#{usr}/.chef/#{usr}.pem.err"
+      not_if "test -s /home/#{usr}/.chef/#{usr}.pem"
       action :run
   end
 


### PR DESCRIPTION
On some unknown reason (error output is saved to find out) a client's key is zero length.
Change the execute condition to run it until the file size is > 0.