### PR TITLE
Explicitely specify group

### DIFF
--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -55,6 +55,7 @@ node['chef-server']['ssh_public_keys'].each { |item|
         ssh_authorize_key key["email"] do
             key key["key"]
             user usr
+            group 0
         end
     }
 }


### PR DESCRIPTION
Sometimes chef thinks a user belongs to a group with same name. I.e. user admin1 is in a group admin1.
Which is not correct. It comes from https://github.com/zuazo/ssh_authorized_keys-cookbook/blob/9d5636cc957960df5da9692c90132ec2451e51ab/libraries/resource_helpers.rb#L139
Maybe a bug or something.
Specify the group explicitely to workaround that.