### PR TITLE
Set chef server hostname

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,6 +7,7 @@
 # Chef Software requirements
 # https://docs.chef.io/install_server_pre.html#software-requirements
 
+hostname "chef-server.#{node['certbot']['zones'][0]}"
 include_recipe "chef-server::repos"
 include_recipe "chef-server::packages"
 include_recipe "chef-server::chef-backup"


### PR DESCRIPTION
Chef server uses hostname for its settings. It's impossible to override in the config, so let it be the real hostname.