### PR TITLE
fixing cleanup script

### DIFF
--- a/files/cleanup-nodes.sh
+++ b/files/cleanup-nodes.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 # Find nodes that never converged
-unconverged_nodes=$(knife status | grep "has not yet converged." | awk '{ print $2 }')
+unconverged_nodes=$(knife status | awk '/has not yet converged./ { print $2 }')
 
 for node in ${unconverged_nodes}
 do
@@ -12,7 +12,7 @@ do
 done
 
 # FInd nodes that didn't ping the server more than 240 hours
-old_nodes=$(knife status | grep "hours ago" | awk '{ if ($1 > 240) print $4 }' | sed 's/,$//')
+old_nodes=$(knife status | awk '/hours ago/ { if ($1 > 240) print $4 }' | sed 's/,$//')
 
 for node in ${old_nodes}
 do


### PR DESCRIPTION
starting status:

```
[istvan@chef-server ~]$ knife status
2109 hours ago, bastion, centos 7.6.1810.
2085 hours ago, i-05503e9f0825e6401, centos 7.6.1810.
2085 hours ago, i-01f19ea1262748a43, centos 7.6.1810.
2084 hours ago, i-0b2a6dd75747eaa9b, centos 7.7.1908.
2079 hours ago, i-0c3a0ead71efb94d3, centos 7.6.1810.
1943 hours ago, i-0b9e04218263c8472, centos 7.6.1810.
1943 hours ago, i-05895823795b8e158, centos 7.6.1810.
1942 hours ago, i-093f0498d3e325f0d, centos 7.6.1810.
1917 hours ago, i-0b7b54263f65ecdb2, centos 7.6.1810.
1774 hours ago, i-0fc40e741526014b9, centos 7.6.1810.
1765 hours ago, i-0257b357b8f2c839f, ubuntu 18.04.
1389 hours ago, i-084b22abab7580a0c, ubuntu 18.04.
833 hours ago, i-03d47666900f40df6, ubuntu 18.04.
517 hours ago, i-02f285e87a01d6571, ubuntu 18.04.
516 hours ago, i-09968f9a0fcfa26b7, ubuntu 18.04.
288 hours ago, i-0a48399999d4776b5, ubuntu 18.04.
141 hours ago, i-0449b123518074a6c, ubuntu 18.04.
65 hours ago, i-0475a438648cbedef, ubuntu 18.04.
63 hours ago, i-06d8b151298792601, ubuntu 18.04.
4 minutes ago, i-0bee90457c7439860, ubuntu 18.04.
```

trimmed test output
```
[istvan@chef-server ~]$ bash cleanup_nodes.sh
++ knife status
++ awk '/has not yet converged./ { print $2 }'
+ unconverged_nodes=
++ knife status
++ awk '/hours ago/ { if ($1 > 240) print $4 }'
++ sed 's/,$//'
+ old_nodes='bastion
i-05503e9f0825e6401
i-01f19ea1262748a43
i-0b2a6dd75747eaa9b
i-0c3a0ead71efb94d3
i-0b9e04218263c8472
i-05895823795b8e158
i-093f0498d3e325f0d
i-0b7b54263f65ecdb2
i-0fc40e741526014b9
i-0257b357b8f2c839f
i-084b22abab7580a0c
i-03d47666900f40df6
i-02f285e87a01d6571
i-09968f9a0fcfa26b7
i-0a48399999d4776b5'
+ for node in '${old_nodes}'
+ echo knife node delete bastion -y
knife node delete bastion -y
+ echo knife client delete bastion -y
knife client delete bastion -y
+ for node in '${old_nodes}'
+ echo knife node delete i-05503e9f0825e6401 -y
knife node delete i-05503e9f0825e6401 -y
+ echo knife client delete i-05503e9f0825e6401 -y
knife client delete i-05503e9f0825e6401 -y
+ for node in '${old_nodes}'
+ echo knife node delete i-01f19ea1262748a43 -y
....
```